### PR TITLE
Fix loading of sample contacts after encryption

### DIFF
--- a/src/main/java/seedu/address/commons/util/FileEncryptor.java
+++ b/src/main/java/seedu/address/commons/util/FileEncryptor.java
@@ -22,7 +22,7 @@ import javax.crypto.spec.PBEParameterSpec;
  */
 public class FileEncryptor {
 
-    public static String extension = ".encrypted";
+    private static String extension = ".encrypted";
     private static String filename = "";
     private static String message = "";
 
@@ -183,5 +183,10 @@ public class FileEncryptor {
      */
     public String getMessage () {
         return this.message;
+    }
+
+    //@@author lekoook
+    public static String getExtension() {
+        return extension;
     }
 }

--- a/src/main/java/seedu/address/commons/util/FileEncryptor.java
+++ b/src/main/java/seedu/address/commons/util/FileEncryptor.java
@@ -22,7 +22,7 @@ import javax.crypto.spec.PBEParameterSpec;
  */
 public class FileEncryptor {
 
-    private static String extension = ".encrypted";
+    public static String extension = ".encrypted";
     private static String filename = "";
     private static String message = "";
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -6,7 +6,14 @@ import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Kpi;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Note;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Position;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -15,24 +22,24 @@ import seedu.address.model.tag.Tag;
 public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
-            // new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-            //    new Address("Blk 30 Geylang Street 29, #06-40"), new Note("Alex is a friend"),
-            //    getTagSet("friends")),
-            // new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-            //     new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Note("Bernice is a friend"),
-            //    getTagSet("colleagues", "friends")),
-            // new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-            //     new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new Note("Charlotte is a friend"),
-            //     getTagSet("neighbours")),
-            // new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-            //     new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new Note("David is a friend"),
-            //     getTagSet("family")),
-            // new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-            //     new Address("Blk 47 Tampines Street 20, #17-35"), new Note("Irfan is a friend"),
-            //     getTagSet("classmates")),
-            // new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-            //     new Address("Blk 45 Aljunied Street 85, #11-31"), new Note("Roy is a friend"),
-            //     getTagSet("colleagues"))
+            new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
+                new Address("Blk 30 Geylang Street 29, #06-40"), new Position("CEO"), new Kpi("0"),
+                new Note("Alex is a friend"), getTagSet("friends")),
+            new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
+                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Position("CEO"), new Kpi("0"),
+                new Note("Bernice is a friend"), getTagSet("colleagues", "friends")),
+            new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
+                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new Position("CEO"), new Kpi("0"),
+                new Note("Charlotte is a friend"), getTagSet("neighbours")),
+            new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
+                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new Position("CEO"), new Kpi("0"),
+                new Note("David is a friend"), getTagSet("family")),
+            new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
+                new Address("Blk 47 Tampines Street 20, #17-35"), new Position("CEO"), new Kpi("0"),
+                new Note("Irfan is a friend"), getTagSet("classmates")),
+            new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
+                new Address("Blk 45 Aljunied Street 85, #11-31"), new Position("CEO"), new Kpi("0"),
+                new Note("Roy is a friend"), getTagSet("colleagues"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
@@ -6,12 +6,14 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.logging.Logger;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.FileEncryptor;
 import seedu.address.commons.util.FileUtil;
 import seedu.address.model.ReadOnlyAddressBook;
 
@@ -23,6 +25,7 @@ public class XmlAddressBookStorage implements AddressBookStorage {
     private static final Logger logger = LogsCenter.getLogger(XmlAddressBookStorage.class);
 
     private Path filePath;
+    private Path encryptedFilePath;
 
     public XmlAddressBookStorage(Path filePath) {
         this.filePath = filePath;
@@ -45,8 +48,9 @@ public class XmlAddressBookStorage implements AddressBookStorage {
     public Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) throws DataConversionException,
                                                                                  FileNotFoundException {
         requireNonNull(filePath);
+        encryptedFilePath = Paths.get(filePath.toString() + FileEncryptor.extension);
 
-        if (!Files.exists(filePath)) {
+        if (!Files.exists(filePath) && !Files.exists(encryptedFilePath)) {
             logger.info("AddressBook file " + filePath + " not found");
             return Optional.empty();
         }

--- a/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
@@ -48,7 +48,7 @@ public class XmlAddressBookStorage implements AddressBookStorage {
     public Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) throws DataConversionException,
                                                                                  FileNotFoundException {
         requireNonNull(filePath);
-        encryptedFilePath = Paths.get(filePath.toString() + FileEncryptor.extension);
+        encryptedFilePath = Paths.get(filePath.toString() + FileEncryptor.getExtension());
 
         if (!Files.exists(filePath) && !Files.exists(encryptedFilePath)) {
             logger.info("AddressBook file " + filePath + " not found");


### PR DESCRIPTION
Bug:
After encrypting the address book and restarting, the sample contacts
will still be loaded.

Issue:
Due to the encrypted file having a different file extension from the
decrypted file, conditional check to determine if a valid address book
already exists will fail.

Fix:
Added a conditional check to determine if an encrypted address book
exists.