### PR TITLE
Text prediction v1.2 rev1

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -120,8 +120,10 @@ public class ArgumentTokenizer {
 
         int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getPrefix().length();
         String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
-
-        return value.trim();
+        if (value.trim().isEmpty()) {
+            value = value.trim();
+        }
+        return value;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -145,9 +145,16 @@ public class ArgumentTokenizer {
         }
     }
 
+    /**
+     * Determines the last Prefix given an argument string.
+     * @param arguments the argument string to search from.
+     * @param prefixes the prefixes that wants to be considered and searched.
+     * @return the last Prefix in the argument string.
+     */
     public static Prefix findLastPrefix(String arguments, Prefix... prefixes) {
         List<PrefixPosition> positionList = findAllPrefixPositions(arguments, prefixes);
         int max = 0;
+        // Returns an invalid Prefix if no last prefix could be found.
         Prefix prefix = CliSyntax.PREFIX_INVALID;
         for (PrefixPosition position : positionList) {
             if (position.startPosition >= max) {

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -145,4 +145,16 @@ public class ArgumentTokenizer {
         }
     }
 
+    public static Prefix findLastPrefix(String arguments, Prefix... prefixes) {
+        List<PrefixPosition> positionList = findAllPrefixPositions(arguments, prefixes);
+        int max = 0;
+        Prefix prefix = CliSyntax.PREFIX_INVALID;
+        for (PrefixPosition position : positionList) {
+            if (position.startPosition >= max) {
+                max = position.startPosition;
+                prefix = position.prefix;
+            }
+        }
+        return prefix;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,6 +15,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_KPI = new Prefix("k/");
     public static final Prefix PREFIX_POSITION = new Prefix("r/");
     public static final Prefix PREFIX_ALL = new Prefix("all/");
+    public static final Prefix PREFIX_COMMAND = new Prefix("command/");
+    public static final Prefix PREFIX_INVALID = new Prefix("invalid/");
 
     /* Command keywords */
     public static final String COMMAND_ADD = "add";

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteArgumentsParser.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteArgumentsParser.java
@@ -1,6 +1,10 @@
 //@@author lekoook
 package seedu.address.model.autocomplete;
 
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Prefix;
+
 import static seedu.address.logic.parser.CliSyntax.COMMAND_DELETE;
 import static seedu.address.logic.parser.CliSyntax.COMMAND_FIND;
 import static seedu.address.logic.parser.CliSyntax.COMMAND_IMPORT;
@@ -14,10 +18,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_INVALID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-
-import seedu.address.logic.parser.ArgumentMultimap;
-import seedu.address.logic.parser.ArgumentTokenizer;
-import seedu.address.logic.parser.Prefix;
 
 /**
  * Parses the arguments of a command text input for auto completing the command
@@ -36,17 +36,17 @@ public class AutoCompleteArgumentsParser {
 
         // TODO: Add or remove command support as necessary
         switch(command) {
-            case COMMAND_FIND:
-                return getFindParserPair(arguments, argMultimap);
-            case COMMAND_LIST:
-                return getListParserPair(arguments, argMultimap);
-            case COMMAND_SELECT:
-            case COMMAND_DELETE:
-            case COMMAND_IMPORT:
-            case COMMAND_MAIL:
-                return getMailParserPair(arguments, argMultimap);
-            default:
-                return new AutoCompleteParserPair(PREFIX_INVALID, arguments.trim());
+        case COMMAND_FIND:
+            return getFindParserPair(arguments, argMultimap);
+        case COMMAND_LIST:
+            return getListParserPair(arguments, argMultimap);
+        case COMMAND_SELECT:
+        case COMMAND_DELETE:
+        case COMMAND_IMPORT:
+        case COMMAND_MAIL:
+            return getMailParserPair(arguments, argMultimap);
+        default:
+            return new AutoCompleteParserPair(PREFIX_INVALID, arguments.trim());
         }
     }
 

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteArgumentsParser.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteArgumentsParser.java
@@ -2,52 +2,78 @@
 package seedu.address.model.autocomplete;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INVALID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.CliSyntax;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Parses the arguments of a command text input for auto completing the command
  */
 public class AutoCompleteArgumentsParser {
-    /**
-     * Regex used for Pattern instance
-     */
-    private static final String argumentRegex = "["
-            + PREFIX_NAME.getPrefix()
-            + PREFIX_PHONE.getPrefix()
-            + PREFIX_EMAIL.getPrefix()
-            + PREFIX_ADDRESS.getPrefix()
-            + PREFIX_TAG.getPrefix()
-            + PREFIX_NOTE.getPrefix()
-            + "]";
-    /**
-     * Pattern instance used to separate the arguments
-     */
-    private static final Pattern ARGS_INPUT_FORMAT = Pattern.compile(argumentRegex);
-
-    /**
-     * Default constructor
-     */
-    public AutoCompleteArgumentsParser() {}
 
     /**
      * Parses the arguments to be used for auto completing of commands
-     * @param argsInput the full string of arguments to parse
+     * @param arguments the full string of arguments to parse
      * @return the prefix that will be used for the prediction
      * @throws ParseException if the user input does not conform the expected format
      */
-    public String parseArguments(String argsInput) throws ParseException {
-        final Matcher matcher = ARGS_INPUT_FORMAT.matcher(argsInput.trim());
+    public static AutoCompleteParserPair parse(String command, String arguments, ArgumentMultimap argMultimap) {
+        if (arguments.isEmpty()) {
+            return new AutoCompleteParserPair(PREFIX_COMMAND, command);
+        }
 
+        // TODO: Add or remove command support as necessary
+        switch(command) {
+            case CliSyntax.COMMAND_FIND:
+                return getFindParserPair(arguments, argMultimap);
+            case CliSyntax.COMMAND_SELECT:
+            case CliSyntax.COMMAND_DELETE:
+            case CliSyntax.COMMAND_IMPORT:
+            case CliSyntax.COMMAND_MAIL:
+                return getMailParserPair(arguments, argMultimap);
+            default:
+                return new AutoCompleteParserPair(PREFIX_INVALID, arguments.trim());
+        }
 
-        return "argument parser test output";
+    }
+
+    private static AutoCompleteParserPair getFindParserPair(String arguments, ArgumentMultimap argMultimap) {
+        Prefix lastPrefix = ArgumentTokenizer.findLastPrefix(
+                arguments,
+                PREFIX_NAME,
+                PREFIX_EMAIL,
+                PREFIX_PHONE,
+                PREFIX_ADDRESS,
+                PREFIX_TAG);
+
+        if (argMultimap.getValue(lastPrefix).isPresent()) {
+            return new AutoCompleteParserPair(lastPrefix, argMultimap.getValue(lastPrefix).get());
+        }
+        // Default text prediction is on names
+        return new AutoCompleteParserPair(PREFIX_NAME, arguments);
+    }
+
+    /**
+     * Creates a AutoCompleteParserPair instance based on the last Prefix found in user input.
+     * @param arguments the user input to search.
+     * @param argMultimap used to retrieve the values of the prefix keys.
+     * @return the appropriate AutoCompleteParserPair instance.
+     */
+    private static AutoCompleteParserPair getMailParserPair(String arguments, ArgumentMultimap argMultimap) {
+        Prefix lastPrefix = ArgumentTokenizer.findLastPrefix(arguments, PREFIX_TAG, PREFIX_NAME);
+        if (argMultimap.getValue(lastPrefix).isPresent()) {
+            return new AutoCompleteParserPair(lastPrefix, argMultimap.getValue(lastPrefix).get());
+        }
+        // Default text prediction is on names
+        return  new AutoCompleteParserPair(PREFIX_NAME, arguments);
     }
 }

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteArgumentsParser.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteArgumentsParser.java
@@ -1,6 +1,12 @@
 //@@author lekoook
 package seedu.address.model.autocomplete;
 
+import static seedu.address.logic.parser.CliSyntax.COMMAND_DELETE;
+import static seedu.address.logic.parser.CliSyntax.COMMAND_FIND;
+import static seedu.address.logic.parser.CliSyntax.COMMAND_IMPORT;
+import static seedu.address.logic.parser.CliSyntax.COMMAND_LIST;
+import static seedu.address.logic.parser.CliSyntax.COMMAND_MAIL;
+import static seedu.address.logic.parser.CliSyntax.COMMAND_SELECT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -11,7 +17,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
-import seedu.address.logic.parser.CliSyntax;
 import seedu.address.logic.parser.Prefix;
 
 /**
@@ -31,12 +36,14 @@ public class AutoCompleteArgumentsParser {
 
         // TODO: Add or remove command support as necessary
         switch(command) {
-            case CliSyntax.COMMAND_FIND:
+            case COMMAND_FIND:
                 return getFindParserPair(arguments, argMultimap);
-            case CliSyntax.COMMAND_SELECT:
-            case CliSyntax.COMMAND_DELETE:
-            case CliSyntax.COMMAND_IMPORT:
-            case CliSyntax.COMMAND_MAIL:
+            case COMMAND_LIST:
+                return getListParserPair(arguments, argMultimap);
+            case COMMAND_SELECT:
+            case COMMAND_DELETE:
+            case COMMAND_IMPORT:
+            case COMMAND_MAIL:
                 return getMailParserPair(arguments, argMultimap);
             default:
                 return new AutoCompleteParserPair(PREFIX_INVALID, arguments.trim());
@@ -44,7 +51,7 @@ public class AutoCompleteArgumentsParser {
     }
 
     /**
-     * Creates a AutoCompleteParserPair instance based on the last Prefix found in user input.
+     * Creates a AutoCompleteParserPair instance based on the last Prefix found in find command.
      * @param arguments the user input to search.
      * @param argMultimap used to retrieve the values of the prefix keys.
      * @return the appropriate AutoCompleteParserPair instance.
@@ -66,7 +73,7 @@ public class AutoCompleteArgumentsParser {
     }
 
     /**
-     * Creates a AutoCompleteParserPair instance based on the last Prefix found in user input.
+     * Creates a AutoCompleteParserPair instance based on the last Prefix found in mail command.
      * @param arguments the user input to search.
      * @param argMultimap used to retrieve the values of the prefix keys.
      * @return the appropriate AutoCompleteParserPair instance.
@@ -77,6 +84,23 @@ public class AutoCompleteArgumentsParser {
             return new AutoCompleteParserPair(lastPrefix, argMultimap.getValue(lastPrefix).get());
         }
         // Default text prediction is names
-        return  new AutoCompleteParserPair(PREFIX_NAME, arguments);
+        return new AutoCompleteParserPair(PREFIX_NAME, arguments);
+    }
+
+    /**
+     * Creates a AutoCompleteParserPair instance based on the last Prefix found in list command.
+     * @param arguments the user input to search.
+     * @param argMultimap used to retrieve the values of the prefix keys.
+     * @return the appropriate AutoCompleteParserPair instance.
+     */
+    private static AutoCompleteParserPair getListParserPair(String arguments, ArgumentMultimap argMultimap) {
+        Prefix lastPrefix = ArgumentTokenizer.findLastPrefix(
+                arguments,
+                PREFIX_TAG);
+        if (argMultimap.getValue(lastPrefix).isPresent()) {
+            return new AutoCompleteParserPair(lastPrefix, argMultimap.getValue(lastPrefix).get());
+        }
+        // Default text prediction is nothing
+        return new AutoCompleteParserPair(PREFIX_INVALID, arguments);
     }
 }

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteArgumentsParser.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteArgumentsParser.java
@@ -1,10 +1,6 @@
 //@@author lekoook
 package seedu.address.model.autocomplete;
 
-import seedu.address.logic.parser.ArgumentMultimap;
-import seedu.address.logic.parser.ArgumentTokenizer;
-import seedu.address.logic.parser.Prefix;
-
 import static seedu.address.logic.parser.CliSyntax.COMMAND_DELETE;
 import static seedu.address.logic.parser.CliSyntax.COMMAND_FIND;
 import static seedu.address.logic.parser.CliSyntax.COMMAND_IMPORT;
@@ -18,6 +14,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_INVALID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Prefix;
 
 /**
  * Parses the arguments of a command text input for auto completing the command

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteArgumentsParser.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteArgumentsParser.java
@@ -13,7 +13,6 @@ import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.CliSyntax;
 import seedu.address.logic.parser.Prefix;
-import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Parses the arguments of a command text input for auto completing the command
@@ -24,7 +23,6 @@ public class AutoCompleteArgumentsParser {
      * Parses the arguments to be used for auto completing of commands
      * @param arguments the full string of arguments to parse
      * @return the prefix that will be used for the prediction
-     * @throws ParseException if the user input does not conform the expected format
      */
     public static AutoCompleteParserPair parse(String command, String arguments, ArgumentMultimap argMultimap) {
         if (arguments.isEmpty()) {
@@ -43,9 +41,14 @@ public class AutoCompleteArgumentsParser {
             default:
                 return new AutoCompleteParserPair(PREFIX_INVALID, arguments.trim());
         }
-
     }
 
+    /**
+     * Creates a AutoCompleteParserPair instance based on the last Prefix found in user input.
+     * @param arguments the user input to search.
+     * @param argMultimap used to retrieve the values of the prefix keys.
+     * @return the appropriate AutoCompleteParserPair instance.
+     */
     private static AutoCompleteParserPair getFindParserPair(String arguments, ArgumentMultimap argMultimap) {
         Prefix lastPrefix = ArgumentTokenizer.findLastPrefix(
                 arguments,
@@ -58,7 +61,7 @@ public class AutoCompleteArgumentsParser {
         if (argMultimap.getValue(lastPrefix).isPresent()) {
             return new AutoCompleteParserPair(lastPrefix, argMultimap.getValue(lastPrefix).get());
         }
-        // Default text prediction is on names
+        // Default text prediction is names
         return new AutoCompleteParserPair(PREFIX_NAME, arguments);
     }
 
@@ -73,7 +76,7 @@ public class AutoCompleteArgumentsParser {
         if (argMultimap.getValue(lastPrefix).isPresent()) {
             return new AutoCompleteParserPair(lastPrefix, argMultimap.getValue(lastPrefix).get());
         }
-        // Default text prediction is on names
+        // Default text prediction is names
         return  new AutoCompleteParserPair(PREFIX_NAME, arguments);
     }
 }

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteParser.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteParser.java
@@ -4,10 +4,6 @@ package seedu.address.model.autocomplete;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.parser.ArgumentMultimap;
-import seedu.address.logic.parser.ArgumentTokenizer;
-import seedu.address.logic.parser.exceptions.ParseException;
-
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INVALID;
@@ -17,6 +13,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Parses the text input for auto completing the command

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteParser.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteParser.java
@@ -85,7 +85,14 @@ public class AutoCompleteParser {
     }
 
     private AutoCompleteParserPair getFindCommandPair(String arguments, ArgumentMultimap argMultimap) {
-        Prefix lastPrefix = ArgumentTokenizer.findLastPrefix(arguments, PREFIX_NAME);
+        Prefix lastPrefix = ArgumentTokenizer.findLastPrefix(
+                arguments,
+                PREFIX_NAME,
+                PREFIX_EMAIL,
+                PREFIX_PHONE,
+                PREFIX_ADDRESS,
+                PREFIX_TAG);
+
         if (argMultimap.getValue(lastPrefix).isPresent()) {
             return new AutoCompleteParserPair(lastPrefix, argMultimap.getValue(lastPrefix).get());
         }

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteParser.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteParser.java
@@ -11,7 +11,9 @@ import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INVALID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_KPI;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
@@ -48,7 +50,7 @@ public class AutoCompleteParser {
         final Matcher matcher = COMMAND_INPUT_FORMAT.matcher(textInput);
 
         if (!matcher.matches()) {
-            return new AutoCompleteParserPair(CliSyntax.PREFIX_INVALID, CliSyntax.PREFIX_INVALID.getPrefix());
+            return new AutoCompleteParserPair(PREFIX_INVALID, PREFIX_INVALID.getPrefix());
         }
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
@@ -66,7 +68,7 @@ public class AutoCompleteParser {
         final String arguments = matcher.group("arguments");
 
         if (arguments.isEmpty()) {
-            return new AutoCompleteParserPair(CliSyntax.PREFIX_COMMAND, commandWord);
+            return new AutoCompleteParserPair(PREFIX_COMMAND, commandWord);
         }
 
         // TODO: Add or remove command support as necessary
@@ -78,7 +80,7 @@ public class AutoCompleteParser {
         case CliSyntax.COMMAND_IMPORT:
         case CliSyntax.COMMAND_MAIL:
         default:
-            return new AutoCompleteParserPair(CliSyntax.PREFIX_INVALID, arguments.trim());
+            return new AutoCompleteParserPair(PREFIX_INVALID, arguments.trim());
         }
     }
 
@@ -87,6 +89,7 @@ public class AutoCompleteParser {
         if (argMultimap.getValue(lastPrefix).isPresent()) {
             return new AutoCompleteParserPair(lastPrefix, argMultimap.getValue(lastPrefix).get());
         }
-        return new AutoCompleteParserPair(CliSyntax.PREFIX_INVALID, arguments);
+        // Default text prediction is on names
+        return new AutoCompleteParserPair(PREFIX_NAME, arguments);
     }
 }

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteParser.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteParser.java
@@ -1,9 +1,6 @@
 //@@author lekoook
 package seedu.address.model.autocomplete;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INVALID;
@@ -13,6 +10,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteParser.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteParser.java
@@ -6,12 +6,9 @@ import java.util.regex.Pattern;
 
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
-import seedu.address.logic.parser.CliSyntax;
-import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INVALID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_KPI;
@@ -66,53 +63,6 @@ public class AutoCompleteParser {
 
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
-
-        if (arguments.isEmpty()) {
-            return new AutoCompleteParserPair(PREFIX_COMMAND, commandWord);
-        }
-
-        // TODO: Add or remove command support as necessary
-        switch(commandWord) {
-        case CliSyntax.COMMAND_FIND:
-            return getFindParserPair(arguments, argMultimap);
-        case CliSyntax.COMMAND_SELECT:
-        case CliSyntax.COMMAND_DELETE:
-        case CliSyntax.COMMAND_IMPORT:
-        case CliSyntax.COMMAND_MAIL:
-            return getMailParserPair(arguments, argMultimap);
-        default:
-            return new AutoCompleteParserPair(PREFIX_INVALID, arguments.trim());
-        }
-    }
-
-    private AutoCompleteParserPair getFindParserPair(String arguments, ArgumentMultimap argMultimap) {
-        Prefix lastPrefix = ArgumentTokenizer.findLastPrefix(
-                arguments,
-                PREFIX_NAME,
-                PREFIX_EMAIL,
-                PREFIX_PHONE,
-                PREFIX_ADDRESS,
-                PREFIX_TAG);
-
-        if (argMultimap.getValue(lastPrefix).isPresent()) {
-            return new AutoCompleteParserPair(lastPrefix, argMultimap.getValue(lastPrefix).get());
-        }
-        // Default text prediction is on names
-        return new AutoCompleteParserPair(PREFIX_NAME, arguments);
-    }
-
-    /**
-     * Creates a AutoCompleteParserPair instance based on the last Prefix found in user input.
-     * @param arguments the user input to search.
-     * @param argMultimap used to retrieve the values of the prefix keys.
-     * @return the appropriate AutoCompleteParserPair instance.
-     */
-    private AutoCompleteParserPair getMailParserPair(String arguments, ArgumentMultimap argMultimap) {
-        Prefix lastPrefix = ArgumentTokenizer.findLastPrefix(arguments, PREFIX_TAG, PREFIX_NAME);
-        if (argMultimap.getValue(lastPrefix).isPresent()) {
-            return new AutoCompleteParserPair(lastPrefix, argMultimap.getValue(lastPrefix).get());
-        }
-        // Default text prediction is on names
-        return  new AutoCompleteParserPair(PREFIX_NAME, arguments);
+        return AutoCompleteArgumentsParser.parse(commandWord, arguments, argMultimap);
     }
 }

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteParser.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteParser.java
@@ -4,8 +4,20 @@ package seedu.address.model.autocomplete;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.CliSyntax;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_KPI;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 /**
  * Parses the text input for auto completing the command
@@ -34,23 +46,47 @@ public class AutoCompleteParser {
      */
     public AutoCompleteParserPair parseCommand(String textInput) {
         final Matcher matcher = COMMAND_INPUT_FORMAT.matcher(textInput);
+
         if (!matcher.matches()) {
-            return new AutoCompleteParserPair(CommandCompleter.COMPLETE_INVALID, CommandCompleter.COMPLETE_INVALID);
+            return new AutoCompleteParserPair(CliSyntax.PREFIX_INVALID, CliSyntax.PREFIX_INVALID.getPrefix());
         }
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
+                textInput,
+                PREFIX_NAME,
+                PREFIX_PHONE,
+                PREFIX_EMAIL,
+                PREFIX_ADDRESS,
+                PREFIX_NOTE,
+                PREFIX_TAG,
+                PREFIX_KPI,
+                PREFIX_POSITION);
 
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
 
         if (arguments.isEmpty()) {
-            return new AutoCompleteParserPair(CommandCompleter.COMPLETE_COMMAND, commandWord);
+            return new AutoCompleteParserPair(CliSyntax.PREFIX_COMMAND, commandWord);
         }
 
+        // TODO: Add or remove command support as necessary
         switch(commandWord) {
         case CliSyntax.COMMAND_FIND:
+            return getFindCommandPair(arguments, argMultimap);
         case CliSyntax.COMMAND_SELECT:
-            return new AutoCompleteParserPair(CommandCompleter.COMPLETE_NAME, arguments.trim());
+        case CliSyntax.COMMAND_DELETE:
+        case CliSyntax.COMMAND_IMPORT:
+        case CliSyntax.COMMAND_MAIL:
         default:
-            return new AutoCompleteParserPair(CommandCompleter.COMPLETE_INVALID, arguments.trim());
+            return new AutoCompleteParserPair(CliSyntax.PREFIX_INVALID, arguments.trim());
         }
+    }
+
+    private AutoCompleteParserPair getFindCommandPair(String arguments, ArgumentMultimap argMultimap) {
+        Prefix lastPrefix = ArgumentTokenizer.findLastPrefix(arguments, PREFIX_NAME);
+        if (argMultimap.getValue(lastPrefix).isPresent()) {
+            return new AutoCompleteParserPair(lastPrefix, argMultimap.getValue(lastPrefix).get());
+        }
+        return new AutoCompleteParserPair(CliSyntax.PREFIX_INVALID, arguments);
     }
 }

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteParser.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteParser.java
@@ -74,17 +74,18 @@ public class AutoCompleteParser {
         // TODO: Add or remove command support as necessary
         switch(commandWord) {
         case CliSyntax.COMMAND_FIND:
-            return getFindCommandPair(arguments, argMultimap);
+            return getFindParserPair(arguments, argMultimap);
         case CliSyntax.COMMAND_SELECT:
         case CliSyntax.COMMAND_DELETE:
         case CliSyntax.COMMAND_IMPORT:
         case CliSyntax.COMMAND_MAIL:
+            return getMailParserPair(arguments, argMultimap);
         default:
             return new AutoCompleteParserPair(PREFIX_INVALID, arguments.trim());
         }
     }
 
-    private AutoCompleteParserPair getFindCommandPair(String arguments, ArgumentMultimap argMultimap) {
+    private AutoCompleteParserPair getFindParserPair(String arguments, ArgumentMultimap argMultimap) {
         Prefix lastPrefix = ArgumentTokenizer.findLastPrefix(
                 arguments,
                 PREFIX_NAME,
@@ -98,5 +99,20 @@ public class AutoCompleteParser {
         }
         // Default text prediction is on names
         return new AutoCompleteParserPair(PREFIX_NAME, arguments);
+    }
+
+    /**
+     * Creates a AutoCompleteParserPair instance based on the last Prefix found in user input.
+     * @param arguments the user input to search.
+     * @param argMultimap used to retrieve the values of the prefix keys.
+     * @return the appropriate AutoCompleteParserPair instance.
+     */
+    private AutoCompleteParserPair getMailParserPair(String arguments, ArgumentMultimap argMultimap) {
+        Prefix lastPrefix = ArgumentTokenizer.findLastPrefix(arguments, PREFIX_TAG, PREFIX_NAME);
+        if (argMultimap.getValue(lastPrefix).isPresent()) {
+            return new AutoCompleteParserPair(lastPrefix, argMultimap.getValue(lastPrefix).get());
+        }
+        // Default text prediction is on names
+        return  new AutoCompleteParserPair(PREFIX_NAME, arguments);
     }
 }

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteParserPair.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteParserPair.java
@@ -12,6 +12,6 @@ public class AutoCompleteParserPair {
 
     public AutoCompleteParserPair(Prefix prefixType, String prefixValue) {
         this.prefixType = prefixType;
-        this.prefixValue = prefixValue;
+        this.prefixValue = prefixValue.trim();
     }
 }

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteParserPair.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteParserPair.java
@@ -12,6 +12,6 @@ public class AutoCompleteParserPair {
 
     public AutoCompleteParserPair(Prefix predictionType, String prefixValue) {
         this.predictionType = predictionType;
-        this.prefixValue = prefixValue.trim();
+        this.prefixValue = prefixValue;
     }
 }

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteParserPair.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteParserPair.java
@@ -7,11 +7,11 @@ import seedu.address.logic.parser.Prefix;
  * Pair object used in parsing of commands for auto complete functionality
  */
 public class AutoCompleteParserPair {
-    public final Prefix prefixType;
+    public final Prefix predictionType;
     public final String prefixValue;
 
-    public AutoCompleteParserPair(Prefix prefixType, String prefixValue) {
-        this.prefixType = prefixType;
+    public AutoCompleteParserPair(Prefix predictionType, String prefixValue) {
+        this.predictionType = predictionType;
         this.prefixValue = prefixValue.trim();
     }
 }

--- a/src/main/java/seedu/address/model/autocomplete/AutoCompleteParserPair.java
+++ b/src/main/java/seedu/address/model/autocomplete/AutoCompleteParserPair.java
@@ -1,15 +1,17 @@
 //@@author lekoook
 package seedu.address.model.autocomplete;
 
+import seedu.address.logic.parser.Prefix;
+
 /**
  * Pair object used in parsing of commands for auto complete functionality
  */
 public class AutoCompleteParserPair {
-    public final String parseType;
-    public final String parseValue;
+    public final Prefix prefixType;
+    public final String prefixValue;
 
-    public AutoCompleteParserPair(String parseType, String parseValue) {
-        this.parseType = parseType;
-        this.parseValue = parseValue;
+    public AutoCompleteParserPair(Prefix prefixType, String prefixValue) {
+        this.prefixType = prefixType;
+        this.prefixValue = prefixValue;
     }
 }

--- a/src/main/java/seedu/address/model/autocomplete/CommandCompleter.java
+++ b/src/main/java/seedu/address/model/autocomplete/CommandCompleter.java
@@ -8,6 +8,7 @@ import seedu.address.logic.parser.CliSyntax;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 import seedu.address.model.trie.Trie;
 
 /**
@@ -23,7 +24,6 @@ public class CommandCompleter {
     public static final int COMPLETE_TAG = 4;
     public static final int COMPLETE_COMMAND = 5;
     public static final int COMPLETE_INVALID = 6;
-    public static final String STRING_COMMAND = "command";
 
     /** Model instance to access data */
     private Model model;
@@ -38,6 +38,7 @@ public class CommandCompleter {
     private Trie phoneTrie;
     private Trie emailTrie;
     private Trie addressTrie;
+    private Trie tagTrie;
 
     /**
      * Word lists of strings used to instantiate Trie objects.
@@ -47,6 +48,7 @@ public class CommandCompleter {
     private ArrayList<String> phoneList;
     private ArrayList<String> emailList;
     private ArrayList<String> addressList;
+    private ArrayList<String> tagList;
 
     /**
      * Creates a command completer with the {@code model} data.
@@ -60,6 +62,7 @@ public class CommandCompleter {
         this.phoneList = new ArrayList<>();
         this.emailList = new ArrayList<>();
         this.addressList = new ArrayList<>();
+        this.tagList = new ArrayList<>();
         initLists();
         initTries();
     }
@@ -100,12 +103,17 @@ public class CommandCompleter {
      * Initialises attributes words lists with attribute value in each {@code Person}.
      */
     private void initAttributesLists() {
+        // TODO: prevent duplicates from being added to lists
         ObservableList<Person> list = model.getAddressBook().getPersonList();
         for (Person item : list) {
             nameList.add(item.getName().fullName);
             phoneList.add(item.getPhone().value);
             emailList.add(item.getEmail().value);
             addressList.add(item.getAddress().value);
+            // TODO: find a better way to do this
+            for (Tag tag : item.getTags()) {
+                tagList.add(tag.toString());
+            }
         }
     }
 
@@ -118,6 +126,7 @@ public class CommandCompleter {
         phoneTrie = new Trie(phoneList);
         emailTrie = new Trie(emailList);
         addressTrie = new Trie(addressList);
+        tagTrie = new Trie(tagList);
     }
 
     /**
@@ -140,7 +149,7 @@ public class CommandCompleter {
         case COMPLETE_EMAIL:
             return emailTrie.getPredictList(pair.prefixValue);
         case COMPLETE_TAG:
-            // TODO: support Tags prediction, create Tag trie
+            return tagTrie.getPredictList(pair.prefixValue);
         default:
             return new ArrayList<>();
         }
@@ -155,6 +164,10 @@ public class CommandCompleter {
         phoneTrie.insert(person.getPhone().value);
         emailTrie.insert(person.getEmail().value);
         addressTrie.insert(person.getAddress().value);
+        // TODO: find a better way to do this
+        for (Tag tag : person.getTags()) {
+            tagTrie.insert(tag.toString());
+        }
     }
 
     /**
@@ -166,6 +179,7 @@ public class CommandCompleter {
         phoneTrie.remove(person.getPhone().value);
         emailTrie.remove(person.getEmail().value);
         addressTrie.remove(person.getAddress().value);
+        // TODO: find a way to delete single occurrence tags
     }
 
     /**
@@ -176,6 +190,7 @@ public class CommandCompleter {
         phoneTrie.clear();
         emailTrie.clear();
         addressTrie.clear();
+        tagTrie.clear();
     }
 
     /**
@@ -200,6 +215,9 @@ public class CommandCompleter {
         if (!personToEdit.getAddress().equals(editedPerson.getAddress())) {
             addressTrie.remove(personToEdit.getAddress().value);
             addressTrie.insert(editedPerson.getAddress().value);
+        }
+        if (!personToEdit.getTags().equals(editedPerson.getTags())) {
+            // TODO: find a way to edit the tags data structure
         }
     }
 

--- a/src/main/java/seedu/address/model/autocomplete/CommandCompleter.java
+++ b/src/main/java/seedu/address/model/autocomplete/CommandCompleter.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 
 import javafx.collections.ObservableList;
 import seedu.address.logic.parser.CliSyntax;
-import seedu.address.logic.parser.Prefix;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;

--- a/src/main/java/seedu/address/model/autocomplete/CommandCompleter.java
+++ b/src/main/java/seedu/address/model/autocomplete/CommandCompleter.java
@@ -140,7 +140,7 @@ public class CommandCompleter {
         case COMPLETE_EMAIL:
             return emailTrie.getPredictList(pair.prefixValue);
         case COMPLETE_TAG:
-            // TODO: create Tag trie
+            // TODO: support Tags prediction, create Tag trie
         default:
             return new ArrayList<>();
         }

--- a/src/main/java/seedu/address/model/autocomplete/CommandCompleter.java
+++ b/src/main/java/seedu/address/model/autocomplete/CommandCompleter.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 
 import javafx.collections.ObservableList;
 import seedu.address.logic.parser.CliSyntax;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 import seedu.address.model.trie.Trie;
@@ -15,12 +16,14 @@ import seedu.address.model.trie.Trie;
 public class CommandCompleter {
 
     /** Constants for Trie matching */
-    public static final String COMPLETE_ADDRESS = "address";
-    public static final String COMPLETE_COMMAND = "command";
-    public static final String COMPLETE_EMAIL = "email";
-    public static final String COMPLETE_NAME = "name";
-    public static final String COMPLETE_PHONE = "phone";
-    public static final String COMPLETE_INVALID = "invalid";
+    public static final int COMPLETE_ADDRESS = 0;
+    public static final int COMPLETE_EMAIL = 1;
+    public static final int COMPLETE_NAME = 2;
+    public static final int COMPLETE_PHONE = 3;
+    public static final int COMPLETE_TAG = 4;
+    public static final int COMPLETE_COMMAND = 5;
+    public static final int COMPLETE_INVALID = 6;
+    public static final String STRING_COMMAND = "command";
 
     /** Model instance to access data */
     private Model model;
@@ -124,11 +127,20 @@ public class CommandCompleter {
      */
     public ArrayList<String> predictText(String textInput) {
         AutoCompleteParserPair pair = parser.parseCommand(textInput);
-        switch (pair.parseType) {
+        int prefixType = getPrefixType(pair);
+        switch (prefixType) {
         case COMPLETE_COMMAND:
-            return commandTrie.getPredictList(pair.parseValue);
+            return commandTrie.getPredictList(pair.prefixValue);
         case COMPLETE_NAME:
-            return nameTrie.getPredictList(pair.parseValue);
+            return nameTrie.getPredictList(pair.prefixValue);
+        case COMPLETE_ADDRESS:
+            return addressTrie.getPredictList(pair.prefixValue);
+        case COMPLETE_PHONE:
+            return phoneTrie.getPredictList(pair.prefixValue);
+        case COMPLETE_EMAIL:
+            return emailTrie.getPredictList(pair.prefixValue);
+        case COMPLETE_TAG:
+            // TODO: create Tag trie
         default:
             return new ArrayList<>();
         }
@@ -188,6 +200,29 @@ public class CommandCompleter {
         if (!personToEdit.getAddress().equals(editedPerson.getAddress())) {
             addressTrie.remove(personToEdit.getAddress().value);
             addressTrie.insert(editedPerson.getAddress().value);
+        }
+    }
+
+    /**
+     * Determines the type of prefix to predict it's arguments.
+     * @param pair containing the prefix.
+     * @return the type of prefix.
+     */
+    private int getPrefixType(AutoCompleteParserPair pair) {
+        if (pair.prefixType.equals(CliSyntax.PREFIX_TAG)) {
+            return COMPLETE_TAG;
+        } else if (pair.prefixType.equals(CliSyntax.PREFIX_EMAIL)) {
+            return COMPLETE_EMAIL;
+        } else if (pair.prefixType.equals(CliSyntax.PREFIX_ADDRESS)) {
+            return COMPLETE_ADDRESS;
+        } else if (pair.prefixType.equals(CliSyntax.PREFIX_PHONE)) {
+            return COMPLETE_PHONE;
+        } else if (pair.prefixType.equals(CliSyntax.PREFIX_NAME)) {
+            return COMPLETE_NAME;
+        } else if (pair.prefixType.equals(CliSyntax.PREFIX_COMMAND)) {
+            return COMPLETE_COMMAND;
+        } else {
+            return COMPLETE_INVALID;
         }
     }
 }

--- a/src/main/java/seedu/address/model/autocomplete/CommandCompleter.java
+++ b/src/main/java/seedu/address/model/autocomplete/CommandCompleter.java
@@ -16,18 +16,14 @@ import seedu.address.model.trie.Trie;
  */
 public class CommandCompleter {
 
-    /** Constants for Trie matching */
-    public static final int COMPLETE_ADDRESS = 0;
-    public static final int COMPLETE_EMAIL = 1;
-    public static final int COMPLETE_NAME = 2;
-    public static final int COMPLETE_PHONE = 3;
-    public static final int COMPLETE_TAG = 4;
-    public static final int COMPLETE_COMMAND = 5;
-    public static final int COMPLETE_INVALID = 6;
-
-    /** Model instance to access data */
+    /**
+     * Model instance to access data.
+     */
     private Model model;
 
+    /**
+     * Text prediction parser to parse user input.
+     */
     private AutoCompleteParser parser;
 
     /**
@@ -136,19 +132,19 @@ public class CommandCompleter {
      */
     public ArrayList<String> predictText(String textInput) {
         AutoCompleteParserPair pair = parser.parseCommand(textInput);
-        int prefixType = getPrefixType(pair);
-        switch (prefixType) {
-        case COMPLETE_COMMAND:
+        PredictionType predictionType = getPredictionType(pair);
+        switch (predictionType) {
+        case PREDICT_COMMAND:
             return commandTrie.getPredictList(pair.prefixValue);
-        case COMPLETE_NAME:
+        case PREDICT_NAME:
             return nameTrie.getPredictList(pair.prefixValue);
-        case COMPLETE_ADDRESS:
+        case PREDICT_ADDRESS:
             return addressTrie.getPredictList(pair.prefixValue);
-        case COMPLETE_PHONE:
+        case PREDICT_PHONE:
             return phoneTrie.getPredictList(pair.prefixValue);
-        case COMPLETE_EMAIL:
+        case PREDICT_EMAIL:
             return emailTrie.getPredictList(pair.prefixValue);
-        case COMPLETE_TAG:
+        case PREDICT_TAG:
             return tagTrie.getPredictList(pair.prefixValue);
         default:
             return new ArrayList<>();
@@ -226,21 +222,34 @@ public class CommandCompleter {
      * @param pair containing the prefix.
      * @return the type of prefix.
      */
-    private int getPrefixType(AutoCompleteParserPair pair) {
-        if (pair.prefixType.equals(CliSyntax.PREFIX_TAG)) {
-            return COMPLETE_TAG;
-        } else if (pair.prefixType.equals(CliSyntax.PREFIX_EMAIL)) {
-            return COMPLETE_EMAIL;
-        } else if (pair.prefixType.equals(CliSyntax.PREFIX_ADDRESS)) {
-            return COMPLETE_ADDRESS;
-        } else if (pair.prefixType.equals(CliSyntax.PREFIX_PHONE)) {
-            return COMPLETE_PHONE;
-        } else if (pair.prefixType.equals(CliSyntax.PREFIX_NAME)) {
-            return COMPLETE_NAME;
-        } else if (pair.prefixType.equals(CliSyntax.PREFIX_COMMAND)) {
-            return COMPLETE_COMMAND;
+    private PredictionType getPredictionType(AutoCompleteParserPair pair) {
+        if (pair.predictionType.equals(CliSyntax.PREFIX_TAG)) {
+            return PredictionType.PREDICT_TAG;
+        } else if (pair.predictionType.equals(CliSyntax.PREFIX_EMAIL)) {
+            return PredictionType.PREDICT_EMAIL;
+        } else if (pair.predictionType.equals(CliSyntax.PREFIX_ADDRESS)) {
+            return PredictionType.PREDICT_ADDRESS;
+        } else if (pair.predictionType.equals(CliSyntax.PREFIX_PHONE)) {
+            return PredictionType.PREDICT_PHONE;
+        } else if (pair.predictionType.equals(CliSyntax.PREFIX_NAME)) {
+            return PredictionType.PREDICT_NAME;
+        } else if (pair.predictionType.equals(CliSyntax.PREFIX_COMMAND)) {
+            return PredictionType.PREDICT_COMMAND;
         } else {
-            return COMPLETE_INVALID;
+            return PredictionType.PREDICT_INVALID;
         }
+    }
+
+    /**
+     * Used to determine which Trie data structure to text predict from.
+     */
+    private enum PredictionType {
+        PREDICT_ADDRESS,
+        PREDICT_EMAIL,
+        PREDICT_NAME ,
+        PREDICT_PHONE,
+        PREDICT_TAG,
+        PREDICT_COMMAND,
+        PREDICT_INVALID
     }
 }

--- a/src/main/java/seedu/address/model/autocomplete/CommandCompleter.java
+++ b/src/main/java/seedu/address/model/autocomplete/CommandCompleter.java
@@ -87,6 +87,10 @@ public class CommandCompleter {
         commandList.add(CliSyntax.COMMAND_UNDO);
         commandList.add(CliSyntax.COMMAND_PASSWORD);
         commandList.add(CliSyntax.COMMAND_MAIL);
+        commandList.add(CliSyntax.COMMAND_BACKUP);
+        commandList.add(CliSyntax.COMMAND_RESTORE);
+        commandList.add(CliSyntax.COMMAND_IMPORT);
+        commandList.add(CliSyntax.COMMAND_EXPORT);
     }
 
     /**

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -68,6 +68,6 @@ public class Tag {
         if (!(priority == PRIORITY_LOW)) {
             fullTag += " " + priority;
         }
-        return '[' + fullTag + ']';
+        return fullTag;
     }
 }

--- a/src/main/java/seedu/address/model/trie/Trie.java
+++ b/src/main/java/seedu/address/model/trie/Trie.java
@@ -175,9 +175,9 @@ public class Trie {
             return predictionsList;
         }
 
-        // If startNode has ONLY ONE child, the only possible text prediction is one that has characters up
-        // till the character that has more than one child.
-        if (startNode.getChildrenSize() == 1) {
+        // If startNode has ONE child OR LESS, the only possible text prediction is one that has characters
+        // up till the character that has more than one child or this is the end of the branch.
+        if (startNode.getChildrenSize() <= 1) {
             charStack = buildSingleStack(startNode);
             predictionsList.add(charStack.toString());
             return predictionsList;

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -58,8 +58,8 @@ public class ArgumentTokenizerTest {
         String argsString = "  some random string /t tag with leading and trailing spaces ";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString);
 
-        // Same string expected as preamble, but leading/trailing spaces should be trimmed
-        assertPreamblePresent(argMultimap, argsString.trim());
+        // Same string expected as preamble, leading and trailing white spaces should be kept.
+        assertPreamblePresent(argMultimap, argsString);
 
     }
 
@@ -68,14 +68,14 @@ public class ArgumentTokenizerTest {
         // Preamble present
         String argsString = "  Some preamble string p/ Argument value ";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
-        assertPreamblePresent(argMultimap, "Some preamble string");
-        assertArgumentPresent(argMultimap, pSlash, "Argument value");
+        assertPreamblePresent(argMultimap, "  Some preamble string ");
+        assertArgumentPresent(argMultimap, pSlash, " Argument value ");
 
         // No preamble
         argsString = " p/   Argument value ";
         argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
         assertPreambleEmpty(argMultimap);
-        assertArgumentPresent(argMultimap, pSlash, "Argument value");
+        assertArgumentPresent(argMultimap, pSlash, "   Argument value ");
 
     }
 
@@ -84,18 +84,18 @@ public class ArgumentTokenizerTest {
         // Only two arguments are present
         String argsString = "SomePreambleString -t dashT-Value p/pSlash value";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertPreamblePresent(argMultimap, "SomePreambleString");
+        assertPreamblePresent(argMultimap, "SomePreambleString ");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");
-        assertArgumentPresent(argMultimap, dashT, "dashT-Value");
+        assertArgumentPresent(argMultimap, dashT, " dashT-Value ");
         assertArgumentAbsent(argMultimap, hatQ);
 
         // All three arguments are present
         argsString = "Different Preamble String ^Q111 -t dashT-Value p/pSlash value";
         argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertPreamblePresent(argMultimap, "Different Preamble String");
+        assertPreamblePresent(argMultimap, "Different Preamble String ");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");
-        assertArgumentPresent(argMultimap, dashT, "dashT-Value");
-        assertArgumentPresent(argMultimap, hatQ, "111");
+        assertArgumentPresent(argMultimap, dashT, " dashT-Value ");
+        assertArgumentPresent(argMultimap, hatQ, "111 ");
 
         /* Also covers: Reusing of the tokenizer multiple times */
 
@@ -120,9 +120,9 @@ public class ArgumentTokenizerTest {
         // Two arguments repeated, some have empty values
         String argsString = "SomePreambleString -t dashT-Value ^Q ^Q -t another dashT value p/ pSlash value -t";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertPreamblePresent(argMultimap, "SomePreambleString");
-        assertArgumentPresent(argMultimap, pSlash, "pSlash value");
-        assertArgumentPresent(argMultimap, dashT, "dashT-Value", "another dashT value", "");
+        assertPreamblePresent(argMultimap, "SomePreambleString ");
+        assertArgumentPresent(argMultimap, pSlash, " pSlash value ");
+        assertArgumentPresent(argMultimap, dashT, " dashT-Value ", " another dashT value ", "");
         assertArgumentPresent(argMultimap, hatQ, "", "");
     }
 
@@ -130,9 +130,9 @@ public class ArgumentTokenizerTest {
     public void tokenize_multipleArgumentsJoined() {
         String argsString = "SomePreambleStringp/ pSlash joined-tjoined -t not joined^Qjoined";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertPreamblePresent(argMultimap, "SomePreambleStringp/ pSlash joined-tjoined");
+        assertPreamblePresent(argMultimap, "SomePreambleStringp/ pSlash joined-tjoined ");
         assertArgumentAbsent(argMultimap, pSlash);
-        assertArgumentPresent(argMultimap, dashT, "not joined^Qjoined");
+        assertArgumentPresent(argMultimap, dashT, " not joined^Qjoined");
         assertArgumentAbsent(argMultimap, hatQ);
     }
 


### PR DESCRIPTION
This PR is aimed at increasing the functionalities of the text prediction feature.

The feature is supporting several more command **keywords only**:

1. backup
2. restore
3. import
4. export

PR has added support for several attribute flags.
They include:

1. name
2. email
3. address
4. phone
5. tag (partial)

The tag is partially supported since more support from the Tag attribute component is required.

PR has also fixed two bugs relating two text prediction. Check commits for more details.