### PR TITLE
Adjust MainWindow min. dimensions

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,8 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root maximized="true" minHeight="800.0" minWidth="1000.0" onCloseRequest="#handleExit" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root maximized="true" minHeight="800.0" minWidth="900.0" onCloseRequest="#handleExit"
+         type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>


### PR DESCRIPTION
Previous the min. width is too high, resulting in breaking OS shortcut keys (Windows Key + Left/Right) for split screening applications.